### PR TITLE
Use Pyramid's implicit tween ordering

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,5 +1,6 @@
 [pydocstyle]
-ignore = D104,  # Missing docstring in public package
+ignore = D103,  # Missing docstring in public function
+         D104,  # Missing docstring in public package
                 # Prevents us from having useless comments in __init__.py
          D105,  # Missing docstring in magic method
          D107,  # Missing docstring in __init__

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,6 +1,5 @@
 [pydocstyle]
-ignore = D103,  # Missing docstring in public function
-         D104,  # Missing docstring in public package
+ignore = D104,  # Missing docstring in public package
                 # Prevents us from having useless comments in __init__.py
          D105,  # Missing docstring in magic method
          D107,  # Missing docstring in __init__

--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,7 @@ load-plugins=pylint.extensions.bad_builtin,
 
 [MESSAGES CONTROL]
 disable=bad-continuation,
+        missing-docstring,
         missing-type-doc,
         missing-return-type-doc,
 

--- a/src/pyramid_sanity/__init__.py
+++ b/src/pyramid_sanity/__init__.py
@@ -1,44 +1,19 @@
-"""Main integration into Pyramids automatic configuration hoovering."""
-
-from pyramid.config import PHASE3_CONFIG
-from pyramid.interfaces import ITweens
+from pyramid.tweens import MAIN
 
 from pyramid_sanity._egress import EgressTweenFactory
 from pyramid_sanity._ingress import IngressTweenFactory
 from pyramid_sanity._settings import SanitySettings
 
-__all__ = ["includeme"]
-
-
-def _add_tween(config):
-    sanity_settings = config.registry.settings["pyramid_sanity"]
-    tweens = config.registry.queryUtility(ITweens)
-
-    if sanity_settings.ingress_required:
-        tweens.add_explicit("pyramid_sanity.ingress_tween_factory", IngressTweenFactory)
-
-    if sanity_settings.egress_required:
-        for tween_name, tween_factory in tweens.implicit():
-            tweens.add_explicit(tween_name, tween_factory)
-
-        # Question - `warehouse.sanity` adds this after every individual tween,
-        # but I think it only needs to be in once?
-        tweens.add_explicit(
-            "pyramid_sanity.egress_tween_factory", EgressTweenFactory,
-        )
-
 
 def includeme(config):
-    """Configure `pyramid_sanity` to run when called with `config.include`."""
+    settings = SanitySettings.from_pyramid_settings(config.registry.settings)
 
-    config.registry.settings["pyramid_sanity"] = SanitySettings.from_pyramid_settings(
-        config.registry.settings
-    )
+    # Put the settings into the registry so that other parts of the
+    # pyramid_sanity code can access them.
+    config.registry.settings["pyramid_sanity"] = settings
 
-    # I'm doing bad things, I'm sorry. - dstufft
-    config.action(
-        ("tween", "pyramid_sanity.tween_factory", True),
-        _add_tween,
-        args=(config,),
-        order=PHASE3_CONFIG,
-    )
+    if settings.ingress_required:
+        config.add_tween("pyramid_sanity.IngressTweenFactory")
+
+    if settings.egress_required:
+        config.add_tween("pyramid_sanity.EgressTweenFactory", over=MAIN)

--- a/src/pyramid_sanity/__init__.py
+++ b/src/pyramid_sanity/__init__.py
@@ -4,8 +4,11 @@ from pyramid_sanity._egress import EgressTweenFactory
 from pyramid_sanity._ingress import IngressTweenFactory
 from pyramid_sanity._settings import SanitySettings
 
+__all__ = ["includeme"]
+
 
 def includeme(config):
+    """Initialize this extension."""
     settings = SanitySettings.from_pyramid_settings(config.registry.settings)
 
     # Put the settings into the registry so that other parts of the
@@ -13,7 +16,19 @@ def includeme(config):
     config.registry.settings["pyramid_sanity"] = settings
 
     if settings.ingress_required:
+        # add_tween() with no `under` or `over` arguments will add the tween to
+        # the "top" of the app's tween chain by default (so this tween will be
+        # called first, before any other tweens).
+        #
+        # Other tweens that get added later might get added above this tween, but
+        # it's up to the app to manage that.
         config.add_tween("pyramid_sanity.IngressTweenFactory")
 
     if settings.egress_required:
+        # add_tween() with `over=MAIN` will add the tween to the "bottom" of
+        # the app's tween chain by default (so this tween will be called last,
+        # after any other tweens).
+        #
+        # Other tweens that get added later might get added below this tween,
+        # but it's up to the app to manage that.
         config.add_tween("pyramid_sanity.EgressTweenFactory", over=MAIN)

--- a/tests/unit/pyramid_sanity/__init___test.py
+++ b/tests/unit/pyramid_sanity/__init___test.py
@@ -1,114 +1,60 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
-from pyramid.config import PHASE3_CONFIG, Configurator
-from pyramid.interfaces import ITweens
+from pyramid.config import Configurator
+from pyramid.tweens import MAIN
 
-from pyramid_sanity import (
-    EgressTweenFactory,
-    IngressTweenFactory,
-    _add_tween,
-    includeme,
-)
+from pyramid_sanity import includeme
 
 
 class TestIncludeMe:
-    def test_it_registers_the_config_object(self, pyramid_config, SanitySettings):
+    def test_it_puts_the_settings_into_the_registry(
+        self, pyramid_config, SanitySettings, settings
+    ):
         includeme(config=pyramid_config)
 
         SanitySettings.from_pyramid_settings.assert_called_once_with(
             pyramid_config.registry.settings
         )
 
-        assert (
-            pyramid_config.registry.settings["pyramid_sanity"]
-            == SanitySettings.from_pyramid_settings.return_value
-        )
+        assert pyramid_config.registry.settings["pyramid_sanity"] == settings
 
-    def test_it_registers_the_tween_factory(self, pyramid_config):
-        # This test is kind of nonsense, just testing the code does what it
-        # does.
+    @pytest.mark.parametrize(
+        "ingress_required,egress_required",
+        [(True, True), (False, True), (True, False), (False, False),],
+    )
+    def test_it_adds_the_tweens(
+        self, ingress_required, egress_required, pyramid_config, settings
+    ):
+        settings.ingress_required = ingress_required
+        settings.egress_required = egress_required
+
         includeme(config=pyramid_config)
 
-        pyramid_config.action.assert_called_once_with(
-            ("tween", "pyramid_sanity.tween_factory", True),
-            _add_tween,
-            args=(pyramid_config,),
-            order=PHASE3_CONFIG,
+        ingress_tween_added = (
+            call("pyramid_sanity.IngressTweenFactory")
+            in pyramid_config.add_tween.call_args_list
         )
+        assert ingress_tween_added == ingress_required
 
-    @pytest.fixture
-    def SanitySettings(self, patch):
-        return patch("pyramid_sanity.SanitySettings")
+        egress_tween_added = (
+            call("pyramid_sanity.EgressTweenFactory", over=MAIN)
+            in pyramid_config.add_tween.call_args_list
+        )
+        assert egress_tween_added == egress_required
 
     @pytest.fixture
     def pyramid_config(self):
         with Configurator() as config:
-            with patch.object(config, "action", auto_spec=True):
+            with patch.object(config, "add_tween", auto_spec=True):
                 yield config
 
 
-class TestAddTween:
-    # I'm going to level with you and say I'm not 100% what this is all up to
-    # so these tests are very, what it does, and not very why
+@pytest.fixture(autouse=True)
+def SanitySettings(patch):
+    return patch("pyramid_sanity.SanitySettings")
 
-    def test_it_adds_the_ingress_tween(self, pyramid_config, tweens, sanity_settings):
-        sanity_settings.check_form = True  # Any ingress would do here
-        _add_tween(pyramid_config)
 
-        assert tweens.explicit[0] == (
-            "pyramid_sanity.ingress_tween_factory",
-            IngressTweenFactory,
-        )
-
-    def test_it_doesnt_add_the_ingress_tween_if_not_required(
-        self, pyramid_config, tweens
-    ):
-        _add_tween(pyramid_config)
-
-        assert (
-            "pyramid_sanity.ingress_tween_factory",
-            IngressTweenFactory,
-        ) not in tweens.explicit
-
-    def test_it_adds_the_egress_tween_after_all_tweens(
-        self, pyramid_config, tweens, sanity_settings
-    ):
-        sanity_settings.ascii_safe_redirects = True
-        tweens.add_implicit(
-            "fake_tween", lambda _handler, _registry: None
-        )  # pragma: no cover
-        implicit_tweens = tweens.implicit()
-        assert not tweens.explicit
-
-        _add_tween(pyramid_config)
-
-        for pos, tween in enumerate(implicit_tweens):
-            # All of the implicit tweens are now explicit
-            assert tweens.explicit[pos] == tween
-
-        # And at the end our EgressTweenFactory
-        assert tweens.explicit[-1] == (
-            "pyramid_sanity.egress_tween_factory",
-            EgressTweenFactory,
-        )
-
-    def test_it_doesnt_add_the_egress_if_not_required(self, pyramid_config, tweens):
-        implicit_tweens = tweens.implicit()
-        assert not tweens.explicit
-
-        _add_tween(pyramid_config)
-
-        assert tweens.implicit() == implicit_tweens
-        assert not tweens.explicit
-
-    @pytest.fixture
-    def tweens(self, pyramid_config):
-        return pyramid_config.registry.queryUtility(ITweens)
-
-    @pytest.fixture
-    def pyramid_config(self, sanity_settings):
-        with Configurator() as config:
-            sanity_settings.all_off()
-            config.registry.settings["pyramid_sanity"] = sanity_settings
-            yield config
+@pytest.fixture
+def settings(SanitySettings):
+    return SanitySettings.from_pyramid_settings.return_value


### PR DESCRIPTION
This seems more normal and appropriate for a Pyramid extension than the unusual way that we were adding tweens before (copy-pasted from Warehouse).

I've tested this in h. If you add `pyramid_sanity` to the **bottom** of `app.py` (after all other tweens have already been added) then `pyramid_sanity`'s tweens get added in the desired order:

```diff
diff --git a/h/app.py b/h/app.py
index efc155947..8648aa9b6 100644
--- a/h/app.py
+++ b/h/app.py
@@ -154,3 +154,4 @@ def includeme(config):
    )

    config.include("h_pyramid_sentry")
+    config.include("pyramid_sanity")
```

You can test the order by running `ptweens`:

```terminal
$ tox -qqe dev --run-command 'ptweens conf/development-app.ini'
"pyramid.tweens" config value NOT set (implicitly ordered tweens used)

Implicit Tween Chain

Position    Name
--------    ----
-           INGRESS
0           h.tweens.unicode_crashing_tween_factory
1           pyramid_sanity.IngressTweenFactory
2           h.tweens.cache_header_tween_factory
3           h.tweens.security_header_tween_factory
4           h.tweens.invalid_path_tween_factory
5           h.tweens.redirect_tween_factory
6           pyramid_tm.tm_tween_factory
7           pyramid.tweens.excview_tween_factory
8           h.tweens.rollback_db_session_on_exception_factory
9           h.tweens.conditional_http_tween_factory
10          pyramid_exclog.exclog_tween_factory
11          pyramid_sanity.EgressTweenFactory
-           MAIN
```

Due to the "best effort" nature of Pyramid's implicit tween ordering it is possible to break it by registering another tween **after** including `pyramid_sanity`. For example this change to h would add a tween that breaks `pyramid_sanity`:

```diff
diff --git a/h/app.py b/h/app.py
index efc155947..f963b8c92 100644
--- a/h/app.py
+++ b/h/app.py
@@ -154,3 +154,5 @@ def includeme(config):
    )

    config.include("h_pyramid_sentry")
    config.include("pyramid_sanity")
+    config.add_tween("h.tweens.unicode_crashing_tween_factory")
diff --git a/h/tweens.py b/h/tweens.py
index 1c297b323..9cd5d774a 100644
--- a/h/tweens.py
+++ b/h/tweens.py
@@ -144,3 +144,9 @@ def rollback_db_session_on_exception_factory(handler, registry):
            raise

    return rollback_db_session_on_exception
+
+
+def unicode_crashing_tween_factory(handler, registry):
+    def unicode_crashing_tween(request):
+        request.GET
+    return unicode_crashing_tween
```

This is to be expected, though. It's up to the app to get the tweens in the right order. Either by including `pyramid_sanity` in the right place or by using Pyramid's explicit tween ordering.