### PR TITLE
Use the function (closure) form of tweens

### DIFF
--- a/src/pyramid_sanity/__init__.py
+++ b/src/pyramid_sanity/__init__.py
@@ -1,7 +1,11 @@
 from pyramid.tweens import MAIN
 
-from pyramid_sanity._egress import EgressTweenFactory
-from pyramid_sanity._ingress import IngressTweenFactory
+from pyramid_sanity._egress import ascii_safe_redirects_tween_factory
+from pyramid_sanity._ingress import (
+    invalid_form_tween_factory,
+    invalid_path_info_tween_factory,
+    invalid_query_string_tween_factory,
+)
 from pyramid_sanity._settings import SanitySettings
 
 __all__ = ["includeme"]
@@ -11,24 +15,26 @@ def includeme(config):
     """Initialize this extension."""
     settings = SanitySettings.from_pyramid_settings(config.registry.settings)
 
-    # Put the settings into the registry so that other parts of the
-    # pyramid_sanity code can access them.
-    config.registry.settings["pyramid_sanity"] = settings
+    # add_tween() with no `under` or `over` arguments will add the tween to
+    # the "top" of the app's tween chain by default (so this tween will be
+    # called first, before any other tweens).
+    #
+    # Other tweens that get added later might get added above this tween, but
+    # it's up to the app to manage that.
+    if settings.check_form:
+        config.add_tween("pyramid_sanity.invalid_form_tween_factory")
 
-    if settings.ingress_required:
-        # add_tween() with no `under` or `over` arguments will add the tween to
-        # the "top" of the app's tween chain by default (so this tween will be
-        # called first, before any other tweens).
-        #
-        # Other tweens that get added later might get added above this tween, but
-        # it's up to the app to manage that.
-        config.add_tween("pyramid_sanity.IngressTweenFactory")
+    if settings.check_params:
+        config.add_tween("pyramid_sanity.invalid_query_string_tween_factory")
 
-    if settings.egress_required:
+    if settings.check_path:
+        config.add_tween("pyramid_sanity.invalid_path_info_tween_factory")
+
+    if settings.ascii_safe_redirects:
         # add_tween() with `over=MAIN` will add the tween to the "bottom" of
         # the app's tween chain by default (so this tween will be called last,
         # after any other tweens).
         #
         # Other tweens that get added later might get added below this tween,
         # but it's up to the app to manage that.
-        config.add_tween("pyramid_sanity.EgressTweenFactory", over=MAIN)
+        config.add_tween("pyramid_sanity.ascii_safe_redirects_tween_factory", over=MAIN)

--- a/src/pyramid_sanity/_settings.py
+++ b/src/pyramid_sanity/_settings.py
@@ -42,13 +42,3 @@ class SanitySettings:
                 setattr(config, key, asbool(value))
 
         return config
-
-    @property
-    def egress_required(self):
-        """Get whether any egress options are enabled."""
-        return self.ascii_safe_redirects
-
-    @property
-    def ingress_required(self):
-        """Get whether any ingress options are enabled."""
-        return any((self.check_form, self.check_params, self.check_path))

--- a/tests/unit/pyramid_sanity/_egress_test.py
+++ b/tests/unit/pyramid_sanity/_egress_test.py
@@ -1,22 +1,17 @@
+# @tween_factory confuses PyLint about function arguments:
+# pylint:disable=no-value-for-parameter
+
 import pytest
 
-from pyramid_sanity import EgressTweenFactory
+from pyramid_sanity import ascii_safe_redirects_tween_factory
 
 
-class TestEgressTweenFactory:
-    def test_initialisation(self, handler, registry):
-        tween = EgressTweenFactory(handler, registry)
-
-        assert tween.handler == handler
-
-    def test_it_calls_the_handler(self, tween, request):
+class TestASCIISafeRedirectsTween:
+    def test_it_leaves_non_redirect_responses_alone(self, tween, request, response):
         response = tween(request)
 
-        tween.handler.assert_called_once_with(request)
-        assert response == tween.handler.return_value
+        assert response.location is None
 
-
-class TestChecks:
     def test_it_leaves_ascii_redirects_alone(self, tween, request, response):
         response.location = "/a/b/c"
 
@@ -31,7 +26,6 @@ class TestChecks:
 
         assert response.location == "/%E2%82%AC/%E2%98%83"
 
-
-@pytest.fixture
-def tween(handler, registry):
-    return EgressTweenFactory(handler, registry)
+    @pytest.fixture
+    def tween(self, handler, registry):
+        return ascii_safe_redirects_tween_factory(handler, registry)

--- a/tests/unit/pyramid_sanity/_settings_test.py
+++ b/tests/unit/pyramid_sanity/_settings_test.py
@@ -39,28 +39,6 @@ class TestSanitySettings:
 
         assert getattr(config, field) == expected
 
-    @pytest.mark.parametrize("value,expected", ((True, True), (False, False)))
-    def test_egress_required(self, sanity_settings, value, expected):
-        sanity_settings.all_off()
-        sanity_settings.ascii_safe_redirects = value
-
-        assert sanity_settings.egress_required == expected
-
-    @pytest.mark.parametrize(
-        "field,expected",
-        (
-            ("check_form", True),
-            ("check_params", True),
-            ("check_path", True),
-            ("irrelevant", False),
-        ),
-    )
-    def test_ingress_required(self, sanity_settings, field, expected):
-        sanity_settings.all_off()
-        setattr(sanity_settings, field, True)
-
-        assert sanity_settings.ingress_required == expected
-
     def assert_all_settings_equal(self, sanity_settings, value):
         assert sanity_settings.ascii_safe_redirects == value
         assert sanity_settings.check_form == value

--- a/tests/unit/pyramid_sanity/conftest.py
+++ b/tests/unit/pyramid_sanity/conftest.py
@@ -3,15 +3,9 @@ from unittest.mock import create_autospec
 
 import pytest
 from pyramid.registry import Registry
-from pyramid.request import Request
 from pyramid.response import Response
 
 from pyramid_sanity._settings import SanitySettings
-
-
-@pytest.fixture
-def pyramid_request():
-    return create_autospec(Request, instance=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Use the simpler function / closure form for implementing a Pyramid
tween, rather than the class form.

The class form is a little dodgy:

> You should avoid mutating any state on the tween instance. The tween
> is invoked once per request and any shared mutable state needs to be
> carefully handled to avoid any race conditions.
>
> The closure style performs slightly better and enables you to
> conditionally omit the tween from the request processing pipeline (see
> the following timing tween example), whereas the class style makes it
> easier to have shared mutable state and allows subclassing.
>
> https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html?highlight=add_tween#creating-a-tween

Also split things up into four separate, small tweens that each do one
thing rather than two big tweens that do multiple things. This makes a
couple of things simpler:

* We can conditionally add or not add each tween depending on which
  features are enabled by the settings. So the setting-based logic can
  now all live in one place `includeme()` rather than being split
  between the `includeme()` and the tweens themselves.

* The tweens themselves are now dirt simple and each do only one job. No
  more settings logic in the tweens. One tween per feature. No state in
  the tweens

* It's no longer necessary for `includeme()` to add the `SanitySettings`
  object to the registry, because the tweens no longer need it

* `SanitySettings.ingress_required` and `SanitySettings.egress_required`
  are no longer needed